### PR TITLE
Allow service to be dynamically accessible

### DIFF
--- a/custom/plugins/CoinGatePayment/Resources/services.xml
+++ b/custom/plugins/CoinGatePayment/Resources/services.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="cryptocurrency_payments_via_coingate.coingate_payment_service"
-                 class="CoinGatePayment\Components\CoinGatePayment\CoinGatePaymentService">
+                 class="CoinGatePayment\Components\CoinGatePayment\CoinGatePaymentService" public="true">
         </service>
     </services>
 </container>


### PR DESCRIPTION
Services in the Symfony container are now private by default and do not allow access them directly from the container via ``$container->get()``. This leads for a dynamic injection of ``cryptocurrency_payments_via_coingate.coingate_payment_service`` impossible and results in a critical error during the checkout.